### PR TITLE
Sketch3.3 don't use embedInShapeGroup

### DIFF
--- a/Swatches.sketchplugin
+++ b/Swatches.sketchplugin
@@ -36,7 +36,10 @@ function addSwatch(hexadecimal, count) {
         swatchGroup.frame().height = 180
 
     var colorBlock = swatchGroup.addLayerOfType("rectangle")
-        colorBlock = colorBlock.embedInShapeGroup()
+        if (colorBlock.embedInShapeGroup != undefined) {
+            colorBlock = colorBlock.embedInShapeGroup()
+        }
+
         colorBlock.frame().x = 0
         colorBlock.frame().y = 0
         colorBlock.frame().width = 130


### PR DESCRIPTION
Hello.

Sketch3.3 don't use embedInShapeGroup.
